### PR TITLE
Make compatible with Firefox

### DIFF
--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -380,7 +380,7 @@ class Encoder extends stream.Transform {
     const enc = new Encoder()
     const bs = new NoFilter()
     enc.pipe(bs)
-    for (const o of objs) {
+    for (var o of objs) {
       if (typeof o === 'undefined') {
         enc._pushUndefined()
       } else if (o === null) {


### PR DESCRIPTION
We're having some issues using node-cbor in Firefox (mentioned here: https://github.com/ipfs/js-ipfs/issues/586), it fails with the following message:

```
Firefox 49.0.0 (Linux 0.0.0) ERROR
  SyntaxError: missing = in const declaration
  at webpack:///~/cbor/lib/encoder.js:383:0 <- test/browser.js:41233
```

I've changed `const` to `var` to make it compatible with Firefox. All the tests are still passing.