### PR TITLE
Indefinite byte arrays should be parsed as Buffer

### DIFF
--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -511,8 +511,10 @@ class Decoder extends BinaryParseStream {
           switch (parent[MAJOR]) {
             case MT.BYTE_STRING:
               val = parent.slice()
+              break
             case MT.UTF8_STRING:
               val = parent.toString('utf-8')
+              break
           }
         }
 

--- a/test/decoder.ava.js
+++ b/test/decoder.ava.js
@@ -65,6 +65,18 @@ test('decodeAllSync', t => {
   t.throws(() => cbor.Decoder.decodeAllSync('63666f'), Error)
 })
 
+test('decode indefinite byte string', t => {
+  var indefinite = Buffer.from([
+    0x5F, // indefinite byte string
+    0x43, // byte string length=3
+    1, 2, 3,
+    0xFF  // BREAK
+  ])
+  var expected = Buffer.from([1, 2, 3])
+  var decoded = cbor.Decoder.decodeFirstSync(indefinite)
+  t.deepEqual(decoded, expected)
+});
+
 test.cb('add_tag', t => {
   function replaceTag (val) {
     return {foo: val}


### PR DESCRIPTION
Currently the decoder returns a string (missing a break).