### PR TITLE
Updates bignumber.js dependency to ^6.0

### DIFF
--- a/docs/decoder.js.html
+++ b/docs/decoder.js.html
@@ -28,15 +28,15 @@
 </nav>
 
 <div id="main">
-    
+
     <h1 class="page-title">decoder.js</h1>
-    
-
-    
 
 
 
-    
+
+
+
+
     <section>
         <article>
             <pre class="prettyprint source linenums"><code>'use strict'
@@ -55,7 +55,7 @@ const SIMPLE = constants.SIMPLE
 const SYMS = constants.SYMS
 
 const NEG_ONE = new bignumber(-1)
-const NEG_MAX = NEG_ONE.sub(
+const NEG_MAX = NEG_ONE.minus(
   new bignumber(Number.MAX_SAFE_INTEGER.toString(16), 16))
 const COUNT = Symbol('count')
 const PENDING_KEY = Symbol('pending_key')
@@ -431,7 +431,7 @@ class Decoder extends BinaryParseStream {
           if (val === Number.MAX_SAFE_INTEGER) {
             val = NEG_MAX
           } else if (val instanceof bignumber) {
-            val = NEG_ONE.sub(val)
+            val = NEG_ONE.minus(val)
           } else {
             val = -1 - val
           }

--- a/docs/encoder.js.html
+++ b/docs/encoder.js.html
@@ -28,15 +28,15 @@
 </nav>
 
 <div id="main">
-    
+
     <h1 class="page-title">encoder.js</h1>
-    
-
-    
 
 
 
-    
+
+
+
+
     <section>
         <article>
             <pre class="prettyprint source linenums"><code>'use strict'
@@ -368,7 +368,7 @@ class Encoder extends stream.Transform {
     }
 
     const dec = obj.decimalPlaces()
-    const slide = obj.mul(new bignumber(10).pow(dec))
+    const slide = obj.times(new bignumber(10).pow(dec))
     if (!gen._pushIntNum(-dec)) {
       return false
     }

--- a/docs/encoder.js.html
+++ b/docs/encoder.js.html
@@ -372,7 +372,7 @@ class Encoder extends stream.Transform {
     if (!gen._pushIntNum(-dec)) {
       return false
     }
-    if (slide.abs().lessThan(MAXINT_BN)) {
+    if (slide.abs().isLessThan(MAXINT_BN)) {
       return gen._pushIntNum(slide.toNumber())
     } else {
       return gen._pushBigint(slide)

--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -14,7 +14,7 @@ const SIMPLE = constants.SIMPLE
 const SYMS = constants.SYMS
 
 const NEG_ONE = new bignumber(-1)
-const NEG_MAX = NEG_ONE.sub(
+const NEG_MAX = NEG_ONE.minus(
   new bignumber(Number.MAX_SAFE_INTEGER.toString(16), 16))
 const COUNT = Symbol('count')
 const PENDING_KEY = Symbol('pending_key')
@@ -390,7 +390,7 @@ class Decoder extends BinaryParseStream {
           if (val === Number.MAX_SAFE_INTEGER) {
             val = NEG_MAX
           } else if (val instanceof bignumber) {
-            val = NEG_ONE.sub(val)
+            val = NEG_ONE.minus(val)
           } else {
             val = -1 - val
           }

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -331,7 +331,7 @@ class Encoder extends stream.Transform {
     if (!gen._pushIntNum(-dec)) {
       return false
     }
-    if (slide.abs().lessThan(MAXINT_BN)) {
+    if (slide.abs().isLessThan(MAXINT_BN)) {
       return gen._pushIntNum(slide.toNumber())
     } else {
       return gen._pushBigint(slide)

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -327,7 +327,7 @@ class Encoder extends stream.Transform {
     }
 
     const dec = obj.decimalPlaces()
-    const slide = obj.mul(new bignumber(10).pow(dec))
+    const slide = obj.times(new bignumber(10).pow(dec))
     if (!gen._pushIntNum(-dec)) {
       return false
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -843,9 +843,9 @@
       "dev": true
     },
     "bignumber.js": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.0.2.tgz",
-      "integrity": "sha1-LR3DfuWWiGfs6pC22k0W5oYI0h0="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-6.0.0.tgz",
+      "integrity": "sha512-x247jIuy60/+FtMRvscqfxtVHQf8AGx2hm9c6btkgC0x/hp9yt+teISNhvF8WlwRkCc5yF2fDECH8SIMe8j+GA=="
     },
     "binary-extensions": {
       "version": "1.8.0",
@@ -2742,14 +2742,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -2758,6 +2750,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -6726,15 +6726,6 @@
         "duplexer": "0.1.1"
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
@@ -6754,6 +6745,15 @@
         "define-properties": "1.1.2",
         "es-abstract": "1.7.0",
         "function-bind": "1.1.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
-    "bignumber.js": "^4.0",
+    "bignumber.js": "^6.0",
     "commander": "^2.11",
     "json-text-sequence": "^0.1",
     "nofilter": "^0.0.3"


### PR DESCRIPTION
Hi!
From bignumber.js was removed alias `sub` for `minus` method. And if you use a few dependencies which used bignumber.js and node-cbor, it has error 'NEG_ONE.sub is not a function'.