### PR TITLE
Remove buffers `noAssert` argument

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,11 +12,11 @@ const MAX_SAFE_HIGH = 0x1fffff
 exports.parseCBORint = function(ai, buf) {
   switch (ai) {
     case NUMBYTES.ONE:
-      return buf.readUInt8(0, true)
+      return buf.readUInt8(0)
     case NUMBYTES.TWO:
-      return buf.readUInt16BE(0, true)
+      return buf.readUInt16BE(0)
     case NUMBYTES.FOUR:
-      return buf.readUInt32BE(0, true)
+      return buf.readUInt32BE(0)
     case NUMBYTES.EIGHT:
       const f = buf.readUInt32BE(0)
       const g = buf.readUInt32BE(4)
@@ -121,9 +121,9 @@ exports.parseCBORfloat = function parseCBORfloat(buf) {
     case 2:
       return exports.parseHalf(buf)
     case 4:
-      return buf.readFloatBE(0, true)
+      return buf.readFloatBE(0)
     case 8:
-      return buf.readDoubleBE(0, true)
+      return buf.readDoubleBE(0)
     default:
       throw new Error('Invalid float size: ' + buf.length)
   }


### PR DESCRIPTION
Support for the `noAssert` argument dropped in the upcoming Node.js
v.10. This removes the argument to make sure everything works as it
should.

Refs: https://github.com/nodejs/node/pull/18395