### PR TITLE
Add offset

### DIFF
--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -178,7 +178,7 @@ class Encoder extends stream.Transform {
       }
       const b4 = new Buffer(4)
       b4.writeFloatBE(obj)
-      if (b4.readFloatBE() === obj) {
+      if (b4.readFloatBE(0) === obj) {
         return this._pushUInt8(FLOAT) && this.push(b4)
       }
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -46,7 +46,7 @@ exports.writeHalf = function writeHalf(buf, half) {
 
   const u32 = new Buffer(4)
   u32.writeFloatBE(half)
-  const u = u32.readUInt32BE()
+  const u = u32.readUInt32BE(0)
 
   // if ((u32.u & 0x1FFF) == 0) { /* worth trying half */
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
   "contributors": [
     "Patrick Gansterer <paroga@paroga.com> (http://paroga.com/)",
     "Artyom Yagilev <github@scorpi.org> (http://scorpi.org/)",
-    "Denis Lapaev <den@lapaev.me> (http://lapaev.me/)"
+    "Denis Lapaev <den@lapaev.me> (http://lapaev.me/)",
+    "Ruben Bridgewater <ruben@bridgewater.de>"
   ],
   "ava": {
     "files": [


### PR DESCRIPTION
In Node.js 10.x the offset is mandatory. This adds the `0` offset to two calls to make sure everything keeps on working as it should.

Refs: https://github.com/nodejs/node/pull/18395