### PR TITLE
Fix Date object encoding as unix epoch

### DIFF
--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -266,7 +266,7 @@ class Encoder extends stream.Transform {
   }
 
   _pushDate(gen, obj) {
-    return gen._pushTag(TAG.DATE_EPOCH) && gen.pushAny(obj / 1000)
+    return gen._pushTag(TAG.DATE_EPOCH) && gen.pushAny(Math.round(obj / 1000))
   }
 
   _pushBuffer(gen, obj) {


### PR DESCRIPTION
The encoder function for Date objects saved a float value instead of an int due to the division by 1000. By using Math.round, the value float is converted to an int.