### PR TITLE
Use Test vectors from cbor/test-vectors

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "test-vectors"]
+	path = test-vectors
+	url = https://github.com/cbor/test-vectors

--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ const d = new Decoder({tags: { 64000: (val) => {
 Developers
 ----------
 
+The tests for this package use a set of test vectors from RFC 7049 appendix A by importing a machine readable version of them from https://github.com/cbor/test-vectors. For these tests to work, you will need to use the command `git submodule update --init` after cloning or pulling this code.   See https://gist.github.com/gitaarik/8735255#file-git_submodules-md for more information.
+
 Get a list of build steps with `npm run`.  I use `npm run dev`, which rebuilds,
 runs tests, and refreshes a browser window with coverage metrics every time I
 save a `.coffee` file.  If you don't want to run the fuzz tests every time, set

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -212,7 +212,7 @@ class Encoder extends stream.Transform {
   }
 
   _pushIntNum(obj) {
-    if (obj === 0 && 1/obj < 0)
+    if (Object.is(obj,-0))
       return this.push(BUF_NEG_ZERO)
 
     if (obj < 0) {

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -26,6 +26,7 @@ const MAXINT_BN = new bignumber('0x20000000000000')
 const BUF_NAN = Buffer.from('f97e00', 'hex')
 const BUF_INF_NEG = Buffer.from('f9fc00', 'hex')
 const BUF_INF_POS = Buffer.from('f97c00', 'hex')
+const BUF_NEG_ZERO = Buffer.from('f98000', 'hex')
 const LOOP_DETECT = Symbol('CBOR_LOOP_DETECT')
 
 /**
@@ -211,6 +212,9 @@ class Encoder extends stream.Transform {
   }
 
   _pushIntNum(obj) {
+    if (obj === 0 && 1/obj < 0)
+      return this.push(BUF_NEG_ZERO)
+
     if (obj < 0) {
       return this._pushInt(-obj - 1, MT.NEG_INT, obj)
     } else {

--- a/test/cases.js
+++ b/test/cases.js
@@ -1006,5 +1006,5 @@ exports.canonNums = [
   [-Infinity, 'f9fc00'],
   [NaN, 'f97e00'],
   [0, '00'],
-  [-0, '00']
+  [-0, 'f98000']
 ]

--- a/test/test-vectors.ava.js
+++ b/test/test-vectors.ava.js
@@ -19,11 +19,12 @@ vectors.forEach( v => {
       if (v.hasOwnProperty('cbor'))
         t.deepEqual( Buffer.from(v.cbor,"base64"), buffer, "base64 and hex encoded bytes mismatched ")
 
+        t.deepEqual(decoded, redecoded, `round trip error: ${hex} -> ${encoded.toString('hex')}`);
 
         if (v.hasOwnProperty('diagnostic'))
         {
-           return cbor.diagnose(buffer)
-              .then(d => t.deepEqual( d.trim(), v.diagnostic.trim()))
+          return cbor.diagnose(buffer)
+              .then(d => t.deepEqual( d.trim().replace(/_\d+($|\))/,'$1'), v.diagnostic))
         }
 
         if (v.hasOwnProperty('decoded')) {

--- a/test/test-vectors.ava.js
+++ b/test/test-vectors.ava.js
@@ -1,0 +1,34 @@
+const BigNumber = require('bignumber.js')
+const cbor = require('../')
+const test = require('ava')
+const vectors = require('../test-vectors/appendix_a')
+const rterror = 'roundtrip:'
+
+console.log(`${vectors.length} entries in RFC Appendix A test vectors`)
+
+vectors.forEach( v => {
+  const hex = v.hex;
+  if (hex) {
+
+    test(`hex: ${hex}`, t => {
+      const buffer = Buffer.from(hex, "hex")
+      if (v.cbor) 
+        t.deepEqual( Buffer.from(v.cbor,"base64"), buffer, "base64 and hex encoded bytes mismatched ")
+     
+      if (v.hasOwnProperty('decoded')) {
+        const decoded = cbor.decodeFirstSync(buffer)
+        if (!BigNumber.isBigNumber(decoded)) 
+          t.deepEqual(decoded, v.decoded)
+        if (v.roundtrip) {
+          const encoded = cbor.encode(decoded)
+          if (!encoded.equals(buffer))
+            t.fail(`${rterror} ${hex} -> ${encoded.toString("hex")} [${decoded}]`)
+        }
+      } else {
+        t.pass('no decoded member');
+      }
+    })
+  }
+
+});
+

--- a/test/test-vectors.ava.js
+++ b/test/test-vectors.ava.js
@@ -1,50 +1,57 @@
 const BigNumber = require('bignumber.js')
 const cbor = require('../')
 const test = require('ava')
-const vectors = require('../test-vectors/appendix_a')
+var vectors = null;
 const rterror = 'roundtrip:'
+try {
+  vectors = require('../test-vectors/appendix_a')
+} catch (ex) { }
 
-vectors.forEach( v => {
-  const hex = v.hex;
-  if (hex) {
+test('test-vectors', t => {
+  if (vectors) t.pass('test-vectors found')
+  else t.fail('use command `git submodule update --init` to load test-vectors')
+})
 
-    test(`hex: ${hex}`, t => {
-      const buffer = Buffer.from(hex, "hex")
+if (vectors) {
+  vectors.forEach(v => {
+    const hex = v.hex;
+    if (hex) {
+
+      test(`hex: ${hex}`, t => {
+        const buffer = Buffer.from(hex, "hex")
 
 
-      const decoded = cbor.decodeFirstSync(buffer)
-      const encoded = cbor.encode(decoded)
-      const redecoded = cbor.decodeFirstSync(encoded) 
-  
-      if (v.hasOwnProperty('cbor'))
-        t.deepEqual( Buffer.from(v.cbor,"base64"), buffer, "base64 and hex encoded bytes mismatched ")
+        const decoded = cbor.decodeFirstSync(buffer)
+        const encoded = cbor.encode(decoded)
+        const redecoded = cbor.decodeFirstSync(encoded)
+
+        if (v.hasOwnProperty('cbor'))
+          t.deepEqual(Buffer.from(v.cbor, "base64"), buffer, "base64 and hex encoded bytes mismatched ")
 
         t.deepEqual(decoded, redecoded, `round trip error: ${hex} -> ${encoded.toString('hex')}`);
 
-        if (v.hasOwnProperty('diagnostic'))
-        {
+        if (v.hasOwnProperty('diagnostic')) {
           return cbor.diagnose(buffer)
-              .then(d => t.deepEqual( d.trim().replace(/_\d+($|\))/,'$1'), v.diagnostic))
+            .then(d => t.deepEqual(d.trim().replace(/_\d+($|\))/, '$1'), v.diagnostic))
         }
 
         if (v.hasOwnProperty('decoded')) {
 
-        if (!BigNumber.isBigNumber(decoded)) 
-          t.deepEqual(decoded, v.decoded)
-        else 
-          t.deepEqual(decoded, redecoded, "BigNum error")
+          if (!BigNumber.isBigNumber(decoded))
+            t.deepEqual(decoded, v.decoded)
+          else
+            t.deepEqual(decoded, redecoded, "BigNum error")
 
-        // if (v.roundtrip) {
-        //   if (!encoded.equals(buffer)) {
-        //     if (decoded)
-        //     t.fail(`${rterror} ${hex} -> ${encoded.toString("hex")} [${decoded} -> ${cbor.decodeFirstSync(encoded)}]`)
-        //   }
-        // }
-      } else {
-        t.pass('no decoded member');
-      }
-    })
-  }
-
-});
-
+          // if (v.roundtrip) {
+          //   if (!encoded.equals(buffer)) {
+          //     if (decoded)
+          //     t.fail(`${rterror} ${hex} -> ${encoded.toString("hex")} [${decoded} -> ${cbor.decodeFirstSync(encoded)}]`)
+          //   }
+          // }
+        } else {
+          t.pass('no decoded member');
+        }
+      })
+    }
+  })
+}

--- a/test/test-vectors.ava.js
+++ b/test/test-vectors.ava.js
@@ -4,26 +4,41 @@ const test = require('ava')
 const vectors = require('../test-vectors/appendix_a')
 const rterror = 'roundtrip:'
 
-console.log(`${vectors.length} entries in RFC Appendix A test vectors`)
-
 vectors.forEach( v => {
   const hex = v.hex;
   if (hex) {
 
     test(`hex: ${hex}`, t => {
       const buffer = Buffer.from(hex, "hex")
-      if (v.cbor) 
+
+
+      const decoded = cbor.decodeFirstSync(buffer)
+      const encoded = cbor.encode(decoded)
+      const redecoded = cbor.decodeFirstSync(encoded) 
+  
+      if (v.hasOwnProperty('cbor'))
         t.deepEqual( Buffer.from(v.cbor,"base64"), buffer, "base64 and hex encoded bytes mismatched ")
-     
-      if (v.hasOwnProperty('decoded')) {
-        const decoded = cbor.decodeFirstSync(buffer)
+
+
+        if (v.hasOwnProperty('diagnostic'))
+        {
+           return cbor.diagnose(buffer)
+              .then(d => t.deepEqual( d.trim(), v.diagnostic.trim()))
+        }
+
+        if (v.hasOwnProperty('decoded')) {
+
         if (!BigNumber.isBigNumber(decoded)) 
           t.deepEqual(decoded, v.decoded)
-        if (v.roundtrip) {
-          const encoded = cbor.encode(decoded)
-          if (!encoded.equals(buffer))
-            t.fail(`${rterror} ${hex} -> ${encoded.toString("hex")} [${decoded}]`)
-        }
+        else 
+          t.deepEqual(decoded, redecoded, "BigNum error")
+
+        // if (v.roundtrip) {
+        //   if (!encoded.equals(buffer)) {
+        //     if (decoded)
+        //     t.fail(`${rterror} ${hex} -> ${encoded.toString("hex")} [${decoded} -> ${cbor.decodeFirstSync(encoded)}]`)
+        //   }
+        // }
       } else {
         t.pass('no decoded member');
       }


### PR DESCRIPTION
Machine readable test vectors from RFC appendex A, maintained at https://github.com/cbor/test-vectors.

This also fixes one bug discovered using these vectors, #76.

See updated README.md for how to use the git submodule command before testing..