### PR TITLE
Decode a subset of draft typed array tags

### DIFF
--- a/lib/tagged.js
+++ b/lib/tagged.js
@@ -3,6 +3,12 @@
 const bignumber = require('bignumber.js')
 const utils = require('./utils')
 const url = require('url')
+const int64 = require('int64-buffer')
+const Int64LE = int64.Int64LE
+const Uint64LE = int64.Uint64LE
+const Int64BE = int64.Int64BE
+const Uint64BE = int64.Uint64BE
+const ieee754 = require('ieee754')
 
 const MINUS_ONE = new bignumber(-1)
 const TEN = new bignumber(10)
@@ -110,6 +116,113 @@ class Tagged {
 
   static _tag_35(v) {
     return new RegExp(v)
+  }
+
+  static _extract_native(v, ArrayType, extractor, bytesPer, littleEndian) {
+    const bufOffset = v.byteOffset
+    const len = v.byteLength / bytesPer
+    const arr = new ArrayType(len)
+    const dv = new DataView(v.buffer)
+    for (let i = 0; i < len; i++) {
+      const offset = (i * bytesPer) + bufOffset
+      arr[i] = dv[extractor](offset, littleEndian)
+    }
+    return arr
+  }
+
+  static _extract_float16(v, littleEndian) {
+    const len = v.byteLength / 2
+    const arr = new Array(len)
+    for (let i = 0; i < len; i++) {
+      arr[i] = ieee754.read(v, i * 2, littleEndian, 10, 2)
+    }
+    return arr
+  }
+
+  static _tag_65(v) {
+    return Tagged._extract_native(v, Uint16Array, 'getUint16', 2, false)
+  }
+
+  static _tag_66(v) {
+    return Tagged._extract_native(v, Uint32Array, 'getUint32', 4, false)
+  }
+
+  static _tag_67(v) {
+    const buf = v.buffer.slice(v.byteOffset, v.byteOffset + v.byteLength)
+    return new Uint64BE(buf)
+  }
+
+  static _tag_68(v) {
+    const buf = v.buffer.slice(v.byteOffset, v.byteOffset + v.byteLength)
+    return new Uint8ClampedArray(buf)
+  }
+
+  static _tag_69(v) {
+    return Tagged._extract_native(v, Uint16Array, 'getUint16', 2, true)
+  }
+
+  static _tag_70(v) {
+    return Tagged._extract_native(v, Uint32Array, 'getUint32', 4, true)
+  }
+
+  static _tag_71(v) {
+    const buf = v.buffer.slice(v.byteOffset, v.byteOffset + v.byteLength)
+    return new Uint64LE(buf)
+  }
+
+  static _tag_72(v) {
+    const buf = v.buffer.slice(v.byteOffset, v.byteOffset + v.byteLength)
+    return new Int8Array(buf)
+  }
+
+  static _tag_73(v) {
+    return Tagged._extract_native(v, Int16Array, 'getInt16', 2, false)
+  }
+
+  static _tag_74(v) {
+    return Tagged._extract_native(v, Int32Array, 'getInt32', 4, false)
+  }
+
+  static _tag_75(v) {
+    const buf = v.buffer.slice(v.byteOffset, v.byteOffset + v.byteLength)
+    return new Int64BE(buf)
+  }
+
+  static _tag_77(v) {
+    return Tagged._extract_native(v, Int16Array, 'getInt16', 2, true)
+  }
+
+  static _tag_78(v) {
+    return Tagged._extract_native(v, Int32Array, 'getInt32', 4, true)
+  }
+
+  static _tag_79(v) {
+    const buf = v.buffer.slice(v.byteOffset, v.byteOffset + v.byteLength)
+    return new Int64LE(buf)
+  }
+
+  static _tag_80(v) {
+    return Tagged._extract_float16(v, false)
+  }
+
+  static _tag_81(v) {
+    return Tagged._extract_native(v, Float32Array, 'getFloat32', 4, false)
+  }
+
+  static _tag_82(v) {
+    return Tagged._extract_native(v, Float64Array, 'getFloat64', 8, false)
+  }
+
+  static _tag_84(v) {
+    return Tagged._extract_float16(v, true)
+  }
+
+  static _tag_85(v) {
+    return Tagged._extract_native(v, Float32Array, 'getFloat32', 4, true)
+  }
+
+  static _tag_86(v) {
+    return Tagged._extract_native(v, Float64Array, 'getFloat64', 8, true)
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -75,6 +75,8 @@
   "dependencies": {
     "bignumber.js": "^7.2.1",
     "commander": "^2.16.0",
+    "ieee754": "^1.1.12",
+    "int64-buffer": "^0.99.1007",
     "json-text-sequence": "^0.1",
     "nofilter": "^0.0.3"
   },

--- a/test/tagged.ava.js
+++ b/test/tagged.ava.js
@@ -2,6 +2,11 @@
 
 const test = require('ava')
 const cbor = require('../lib/cbor')
+const int64 = require('int64-buffer')
+const Int64LE = int64.Int64LE
+const Uint64LE = int64.Uint64LE
+const Int64BE = int64.Int64BE
+const Uint64BE = int64.Uint64BE
 
 test('create', t => {
   const tag = new cbor.Tagged(1, 'one')
@@ -25,4 +30,164 @@ test('edges', t => {
   t.throws(() => {
     new cbor.Tagged('zero', 'one') // eslint-disable-line
   })
+})
+
+test('decode Uin8Clamped8Array', t => {
+  const buf = Buffer.from('d84443010203', 'hex')
+  const expected = new Uint8ClampedArray([1, 2, 3])
+
+  t.deepEqual(cbor.decode(buf), expected)
+})
+
+test('decode Int8Array', t => {
+  const buf = Buffer.from('d8484301fe03', 'hex')
+  const expected = new Int8Array([1, -2, 3])
+
+  t.deepEqual(cbor.decode(buf), expected)
+})
+
+test('decode Int16Array LE', t => {
+  const buf = Buffer.from('d84d460100feff0300', 'hex')
+  const expected = new Int16Array([1, -2, 3])
+
+  t.deepEqual(cbor.decode(buf), expected)
+})
+
+test('decode Int32Array LE', t => {
+  const buf = Buffer.from('d84e4c01000000feffffff03000000', 'hex')
+  const expected = new Int32Array([1, -2, 3])
+
+  t.deepEqual(cbor.decode(buf), expected)
+})
+
+test('decode Int64Array LE', t => {
+  const buf = Buffer.from(
+    'd84f58180100000000000000feffffffffffffff0300000000000000', 'hex')
+  const exBuffer = Buffer.from(
+    '0100000000000000feffffffffffffff0300000000000000', 'hex')
+  const expected = new Int64LE(new Uint8Array(exBuffer))
+
+  t.deepEqual(cbor.decode(buf), expected)
+})
+
+test('decode UInt16Array LE', t => {
+  const buf = Buffer.from('d84546010002000300', 'hex')
+  const expected = new Uint16Array([1, 2, 3])
+
+  t.deepEqual(cbor.decode(buf), expected)
+})
+
+test('decode UInt32Array LE', t => {
+  const buf = Buffer.from('d8464c010000000200000003000000', 'hex')
+  const expected = new Uint32Array([1, 2, 3])
+
+  t.deepEqual(cbor.decode(buf), expected)
+})
+
+test('decode Uint64Array LE', t => {
+  const buf = Buffer.from(
+    'd8475818010000000000000002000000000000000300000000000000', 'hex')
+  const exBuffer = Buffer.from(
+    '010000000000000002000000000000000300000000000000', 'hex')
+  const expected = new Uint64LE(new Uint8Array(exBuffer))
+
+  t.deepEqual(cbor.decode(buf), expected)
+})
+
+test('decode Float16Array LE', t => {
+  const buf = Buffer.from('d85446663c66c09942', 'hex')
+  const expected = [1.1, -2.2, 3.3]
+
+  const result = cbor.decode(buf)
+  for (let i = 0; i < expected.length; i++) {
+    t.truthy(Math.abs(result[i] - expected[i]) < 1e-2)
+  }
+})
+
+test('decode Float32Array LE', t => {
+  const buf = Buffer.from('d8554ccdcc8c3fcdcc0cc033335340', 'hex')
+  const expected = new Float32Array([1.1, -2.2, 3.3])
+
+  t.deepEqual(cbor.decode(buf), expected)
+})
+
+test('decode Float64Array LE', t => {
+  const buf = Buffer.from(
+    'd85658189a9999999999f13f9a999999999901c06666666666660a40', 'hex')
+  const expected = new Float64Array([1.1, -2.2, 3.3])
+
+  t.deepEqual(cbor.decode(buf), expected)
+})
+
+test('decode Int16Array BE', t => {
+  const buf = Buffer.from('d849460001fffe0003', 'hex')
+  const expected = new Int16Array([1, -2, 3])
+
+  t.deepEqual(cbor.decode(buf), expected)
+})
+
+test('decode Int32Array BE', t => {
+  const buf = Buffer.from('d84a4c00000001fffffffe00000003', 'hex')
+  const expected = new Int32Array([1, -2, 3])
+
+  t.deepEqual(cbor.decode(buf), expected)
+})
+
+test('decode Int64Array BE', t => {
+  const buf = Buffer.from(
+    'd84b58180000000000000001fffffffffffffffe0000000000000003', 'hex')
+  const exBuffer = Buffer.from(
+    '0000000000000001fffffffffffffffe0000000000000003', 'hex')
+  const expected = new Int64BE(new Uint8Array(exBuffer))
+
+  t.deepEqual(cbor.decode(buf), expected)
+})
+
+test('decode UInt16Array BE', t => {
+  const buf = Buffer.from('d84146000100020003', 'hex')
+  const expected = new Uint16Array([1, 2, 3])
+
+  t.deepEqual(cbor.decode(buf), expected)
+})
+
+test('decode UInt32Array BE', t => {
+  const buf = Buffer.from('d8424c000000010000000200000003', 'hex')
+  const expected = new Uint32Array([1, 2, 3])
+
+  t.deepEqual(cbor.decode(buf), expected)
+})
+
+test('decode Uint64Array BE', t => {
+  const buf = Buffer.from(
+    'd8435818000000000000000100000000000000020000000000000003', 'hex')
+  const exBuffer = Buffer.from(
+    '000000000000000100000000000000020000000000000003', 'hex')
+  const expected = new Uint64BE(new Uint8Array(exBuffer))
+
+  t.deepEqual(cbor.decode(buf), expected)
+})
+
+test('decode Float16Array BE', t => {
+  const buf = Buffer.from('d850463c66c0664299', 'hex')
+  const expected = [1.1, -2.2, 3.3]
+
+  const result = cbor.decode(buf)
+  for (let i = 0; i < expected.length; i++) {
+    t.truthy(Math.abs(result[i] - expected[i]) < 1e-2)
+  }
+})
+
+test('decode Float32Array BE', t => {
+  const buf = Buffer.from('d8514c3f8ccccdc00ccccd40533333', 'hex')
+  const expected = new Float32Array([1.1, -2.2, 3.3])
+
+  t.deepEqual(cbor.decode(buf), expected)
+})
+
+test('decode Float64Array BE', t => {
+  const buf = Buffer.from(
+    'd85258183ff199999999999ac00199999999999a400a666666666666', 'hex')
+  const expected = new Float64Array([1.1, -2.2, 3.3])
+
+  t.deepEqual(cbor.decode(buf), expected)
 })


### PR DESCRIPTION
Implement decoding a subset of the [draft typed array tags](https://tools.ietf.org/html/draft-ietf-cbor-array-tags-00).

The following tags are not implemented:
* Float128 arrays (83, 87)
* Homogeneous arrays (41)
* Multi-dimensional arrays (40)