### PR TITLE
Require node Buffer global to allow use with Webpack 5

### DIFF
--- a/lib/commented.js
+++ b/lib/commented.js
@@ -7,6 +7,7 @@ const Simple = require('./simple')
 const Decoder = require('./decoder')
 const NoFilter = require('nofilter')
 const {BigNumber, MT, NUMBYTES, SYMS} = require('./constants')
+const { Buffer } = require('buffer')
 
 function plural(c) {
   if (c > 1) {

--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -7,6 +7,7 @@ const Simple = require('./simple')
 const utils = require('./utils')
 const NoFilter = require('nofilter')
 const {BigNumber, MT, NUMBYTES, SIMPLE, SYMS, BI, BN} = require('./constants')
+const { Buffer } = require('buffer')
 
 const COUNT = Symbol('count')
 const PENDING_KEY = Symbol('pending_key')

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -9,6 +9,7 @@ const utils = require('./utils')
 const {
   BigNumber, MT, NUMBYTES, SHIFT32, SIMPLE, SYMS, TAG, BI, BN
 } = require('./constants')
+const { Buffer } = require('buffer')
 
 const HALF = (MT.SIMPLE_FLOAT << 5) | NUMBYTES.TWO
 const FLOAT = (MT.SIMPLE_FLOAT << 5) | NUMBYTES.FOUR

--- a/lib/map.js
+++ b/lib/map.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Buffer } = require('buffer')
 const encoder = require('./encoder')
 const decoder = require('./decoder')
 const constants = require('./constants')

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Buffer } = require('buffer')
 const NoFilter = require('nofilter')
 const stream = require('stream')
 const util = require('util')

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   "readmeFilename": "README.md",
   "dependencies": {
     "bignumber.js": "^9.0.1",
+    "buffer": "^6.0.3",
     "nofilter": "^1.0.4"
   },
   "engines": {


### PR DESCRIPTION
Webpack 5 removed automatic support for node polyfills so you now can't access the node `Buffer` global in the browser any more - you have to `require` it first.

I've added Feross' [Buffer polyfill](https://www.npmjs.com/package/buffer) as a dependency and `require`d it in the non-cli/test files that use Buffer directly.

If running on node you'll get node's Buffer, if it's the browser you get the polyfill.

It's not worth replacing `Buffer` with `Uint8Array`s entirely because there's no equivalent API to [Buffer.allocUnsafe](https://nodejs.org/api/buffer.html#buffer_static_method_buffer_allocunsafe_size) so it'd be a big performance hit.