### PR TITLE
Add option to not accept maps with duplicate keys

### DIFF
--- a/packages/cbor/package.json
+++ b/packages/cbor/package.json
@@ -41,7 +41,8 @@
     "Artyom Yagilev <github@scorpi.org> (http://scorpi.org/)",
     "Denis Lapaev <den@lapaev.me> (http://lapaev.me/)",
     "Ruben Bridgewater <ruben@bridgewater.de>",
-    "Burt Harris <Burt_Harris_cbor@azxs.33mail.com>"
+    "Burt Harris <Burt_Harris_cbor@azxs.33mail.com>",
+    "Jakub Arbet <hi@jakubarbet.me> (https://jakubarbet.me/)"
   ],
   "types": "./types/lib/cbor.d.ts",
   "dependencies": {

--- a/packages/cbor/test/decoder.ava.js
+++ b/packages/cbor/test/decoder.ava.js
@@ -308,3 +308,33 @@ test('Buffers', t => {
     ],
   })
 })
+
+test('duplicate map keys', t => {
+  // Default behaviour is unchanged and allows parsing maps with duplicate keys
+  t.deepEqual(
+    cbor.decode(Buffer.from('a200010002', 'hex')),
+    new Map([[0, 2]])
+  )
+  // When the new decoder option is set the decode will throw
+  t.throws(() => cbor.decode(Buffer.from('a200010002', 'hex'), {preventDuplicateKeys: true}))
+
+  // Default behaviour for maps with only string keys is also unchanged
+  t.deepEqual(
+    cbor.decode(Buffer.from('a268746f537472696e670068746f537472696e6701', 'hex')),
+    {
+      toString: 1,
+    }
+  )
+
+  // When parsing a map with only strings as keys the result is an object and
+  // we ignore keys from the object's prototype when checking for duplicates
+  t.deepEqual(
+    cbor.decode(Buffer.from('a268746f537472696e670063666f6f01', 'hex'), {preventDuplicateKeys: true}),
+    {
+      toString: 0,
+      foo: 1,
+    }
+  )
+
+  t.throws(() => cbor.decode(Buffer.from('a268746f537472696e670068746f537472696e6701', 'hex'), {preventDuplicateKeys: true}))
+})

--- a/packages/cbor/types/lib/decoder.d.ts
+++ b/packages/cbor/types/lib/decoder.d.ts
@@ -104,6 +104,7 @@ declare class Decoder extends BinaryParseStream {
     preferWeb: boolean;
     extendedResults: boolean;
     required: boolean;
+    preventDuplicateKeys: boolean;
     valueBytes: NoFilter;
     /**
      * Stop processing.
@@ -163,6 +164,11 @@ type DecoderOptions = {
      * The value will already have been null-checked.
      */
     extendedResults?: boolean;
+    /**
+     * If true, error is
+     * thrown if a map has duplicate keys.
+     */
+    preventDuplicateKeys?: boolean;
 };
 type ExtendedResults = {
     /**


### PR DESCRIPTION
This PR adds a Decoder option to prevent the decoder from parsing maps with duplicate keys, which is one of the valid ways to handle duplicate map keys as described in the CBOR RFC.

Citing from CBOR RFC 8949:
[3.1 Major types, Major type 5](https://www.rfc-editor.org/rfc/rfc8949.html#name-major-types)
> A map that has duplicate keys may be well-formed, but it is not valid, and thus it causes indeterminate decoding; see also Section 5.6.

[5.6. Specifying Keys for Maps](https://www.rfc-editor.org/rfc/rfc8949.html#map-keys)
> When processing maps that exhibit entries with duplicate keys, a generic decoder might do one of the following:
> * Not accept maps with duplicate keys ...
> * Pass all map entries to the application ...
> * Lose some entries with duplicate keys, e.g., deliver only the final (or first) entry out of the entries with the same key ...
> Generic decoders need to document which of these three approaches they implement.

I believe this package chose the third option, although not documented, but in my use of CBOR I found it quite useful to have an option to not accept maps with duplicate keys. I decided to implement it via a Decoder option as to not break backwards compatibility.