### PR TITLE
include types for cbor-web

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@cto.af/eslint-config": "^0.1.7",
     "ava": "^4.3.3",
     "bignumber.js": "^9.1.0",
+    "copyfiles": "^2.4.1",
     "eslint": "^8.23.1",
     "eslint-plugin-ava": "^13.2.0",
     "eslint-plugin-jsdoc": "^39.3.6",

--- a/packages/cbor-web/package.json
+++ b/packages/cbor-web/package.json
@@ -3,6 +3,7 @@
   "version": "8.1.0",
   "description": "",
   "main": "dist/cbor.js",
+  "types": "./types/lib/cbor.d.ts",
   "scripts": {
     "build": "webpack",
     "copy": "webpack"

--- a/packages/cbor-web/types/lib/cbor.d.ts
+++ b/packages/cbor-web/types/lib/cbor.d.ts
@@ -1,0 +1,25 @@
+export const Commented: typeof import("./commented");
+export const Diagnose: typeof import("./diagnose");
+export const Decoder: typeof import("./decoder");
+export const Encoder: typeof import("./encoder");
+export const Simple: typeof import("./simple");
+export const Tagged: typeof import("./tagged");
+export const Map: typeof import("./map");
+export namespace leveldb {
+    const decode: typeof import("./decoder").decodeFirstSync;
+    const encode: typeof import("./encoder").encode;
+    const buffer: boolean;
+    const name: string;
+}
+export function reset(): void;
+export const comment: typeof import("./commented").comment;
+export const decodeAll: typeof import("./decoder").decodeAll;
+export const decodeAllSync: typeof import("./decoder").decodeAllSync;
+export const decodeFirst: typeof import("./decoder").decodeFirst;
+export const decodeFirstSync: typeof import("./decoder").decodeFirstSync;
+export const decode: typeof import("./decoder").decodeFirstSync;
+export const diagnose: typeof import("./diagnose").diagnose;
+export const encode: typeof import("./encoder").encode;
+export const encodeCanonical: typeof import("./encoder").encodeCanonical;
+export const encodeOne: typeof import("./encoder").encodeOne;
+export const encodeAsync: typeof import("./encoder").encodeAsync;

--- a/packages/cbor-web/types/lib/commented.d.ts
+++ b/packages/cbor-web/types/lib/commented.d.ts
@@ -1,0 +1,111 @@
+/// <reference types="node" />
+export = Commented;
+/**
+ * Generate the expanded format of RFC 8949, section 3.2.2.
+ *
+ * @extends stream.Transform
+ */
+declare class Commented extends stream.Transform {
+    /**
+     * Comment on an input Buffer or string, creating a string passed to the
+     * callback.  If callback not specified, a promise is returned.
+     *
+     * @static
+     * @param {string|Buffer|ArrayBuffer|Uint8Array|Uint8ClampedArray
+     *   |DataView|stream.Readable} input Something to parse.
+     * @param {CommentOptions|commentCallback|string|number} [options={}]
+     *   Encoding, max_depth, or callback.
+     * @param {commentCallback} [cb] If specified, called on completion.
+     * @returns {Promise} If cb not specified.
+     * @throws {Error} Input required.
+     */
+    static comment(input: string | Buffer | ArrayBuffer | Uint8Array | Uint8ClampedArray | DataView | stream.Readable, options?: CommentOptions | commentCallback | string | number, cb?: commentCallback): Promise<any>;
+    /**
+     * Create a CBOR commenter.
+     *
+     * @param {CommentOptions} [options={}] Stream options.
+     */
+    constructor(options?: CommentOptions);
+    depth: number;
+    max_depth: number;
+    all: NoFilter;
+    parser: Decoder;
+    /**
+     * @param {Buffer} v Descend into embedded CBOR.
+     * @private
+     */
+    private _tag_24;
+    /**
+     * @ignore
+     */
+    _on_error(er: any): void;
+    /**
+     * @ignore
+     */
+    _on_read(buf: any): void;
+    /**
+     * @ignore
+     */
+    _on_more(mt: any, len: any, parent_mt: any, pos: any): void;
+    /**
+     * @ignore
+     */
+    _on_start_string(mt: any, len: any, parent_mt: any, pos: any): void;
+    /**
+     * @ignore
+     */
+    _on_start(mt: any, tag: any, parent_mt: any, pos: any): void;
+    /**
+     * @ignore
+     */
+    _on_stop(mt: any): void;
+    /**
+     * @private
+     */
+    private _on_value;
+    /**
+     * @ignore
+     */
+    _on_data(): void;
+}
+declare namespace Commented {
+    export { CommentOptions, commentCallback };
+}
+import stream = require("stream");
+import NoFilter = require("nofilter");
+import Decoder = require("./decoder");
+import { Buffer } from "buffer";
+type CommentOptions = {
+    /**
+     * How many times to indent
+     * the dashes.
+     */
+    max_depth?: number;
+    /**
+     * Initial indentation depth.
+     */
+    depth?: number;
+    /**
+     * If true, omit the summary
+     * of the full bytes read at the end.
+     */
+    no_summary?: boolean;
+    /**
+     * Mapping from tag number to function(v),
+     * where v is the decoded value that comes after the tag, and where the
+     * function returns the correctly-created value for that tag.
+     */
+    tags?: object;
+    /**
+     * If true, prefer Uint8Arrays to
+     * be generated instead of node Buffers.  This might turn on some more
+     * changes in the future, so forward-compatibility is not guaranteed yet.
+     */
+    preferWeb?: boolean;
+    /**
+     * Encoding to use for input, if it
+     * is a string.
+     */
+    encoding?: BufferEncoding;
+};
+type commentCallback = (error?: Error, commented?: string) => void;

--- a/packages/cbor-web/types/lib/constants.d.ts
+++ b/packages/cbor-web/types/lib/constants.d.ts
@@ -1,0 +1,63 @@
+export namespace MT {
+    const POS_INT: number;
+    const NEG_INT: number;
+    const BYTE_STRING: number;
+    const UTF8_STRING: number;
+    const ARRAY: number;
+    const MAP: number;
+    const TAG: number;
+    const SIMPLE_FLOAT: number;
+}
+export type MT = number;
+export namespace TAG {
+    const DATE_STRING: number;
+    const DATE_EPOCH: number;
+    const POS_BIGINT: number;
+    const NEG_BIGINT: number;
+    const DECIMAL_FRAC: number;
+    const BIGFLOAT: number;
+    const BASE64URL_EXPECTED: number;
+    const BASE64_EXPECTED: number;
+    const BASE16_EXPECTED: number;
+    const CBOR: number;
+    const URI: number;
+    const BASE64URL: number;
+    const BASE64: number;
+    const REGEXP: number;
+    const MIME: number;
+    const SET: number;
+}
+export type TAG = number;
+export namespace NUMBYTES {
+    const ZERO: number;
+    const ONE: number;
+    const TWO: number;
+    const FOUR: number;
+    const EIGHT: number;
+    const INDEFINITE: number;
+}
+export type NUMBYTES = number;
+export namespace SIMPLE {
+    const FALSE: number;
+    const TRUE: number;
+    const NULL: number;
+    const UNDEFINED: number;
+}
+export type SIMPLE = number;
+export namespace SYMS {
+    const NULL_1: symbol;
+    export { NULL_1 as NULL };
+    const UNDEFINED_1: symbol;
+    export { UNDEFINED_1 as UNDEFINED };
+    export const PARENT: symbol;
+    export const BREAK: symbol;
+    export const STREAM: symbol;
+}
+export const SHIFT32: 4294967296;
+export namespace BI {
+    const MINUS_ONE: bigint;
+    const NEG_MAX: bigint;
+    const MAXINT32: bigint;
+    const MAXINT64: bigint;
+    const SHIFT32: bigint;
+}

--- a/packages/cbor-web/types/lib/decoder.d.ts
+++ b/packages/cbor-web/types/lib/decoder.d.ts
@@ -1,0 +1,198 @@
+/// <reference types="node" />
+export = Decoder;
+/**
+ * Decode a stream of CBOR bytes by transforming them into equivalent
+ * JavaScript data.  Because of the limitations of Node object streams,
+ * special symbols are emitted instead of NULL or UNDEFINED.  Fix those
+ * up by calling {@link Decoder.nullcheck}.
+ *
+ * @extends BinaryParseStream
+ */
+declare class Decoder extends BinaryParseStream {
+    /**
+     * Check the given value for a symbol encoding a NULL or UNDEFINED value in
+     * the CBOR stream.
+     *
+     * @static
+     * @param {any} val The value to check.
+     * @returns {any} The corrected value.
+     * @throws {Error} Nothing was found.
+     * @example
+     * myDecoder.on('data', val => {
+     *   val = Decoder.nullcheck(val)
+     *   // ...
+     * })
+     */
+    static nullcheck(val: any): any;
+    /**
+     * Decode the first CBOR item in the input, synchronously.  This will throw
+     * an exception if the input is not valid CBOR, or if there are more bytes
+     * left over at the end (if options.extendedResults is not true).
+     *
+     * @static
+     * @param {BufferLike} input If a Readable stream, must have
+     *   received the `readable` event already, or you will get an error
+     *   claiming "Insufficient data".
+     * @param {DecoderOptions|string} [options={}] Options or encoding for input.
+     * @returns {ExtendedResults|any} The decoded value.
+     * @throws {UnexpectedDataError} Data is left over after decoding.
+     * @throws {Error} Insufficient data.
+     */
+    static decodeFirstSync(input: BufferLike, options?: DecoderOptions | string): ExtendedResults | any;
+    /**
+     * Decode all of the CBOR items in the input into an array.  This will throw
+     * an exception if the input is not valid CBOR; a zero-length input will
+     * return an empty array.
+     *
+     * @static
+     * @param {BufferLike} input What to parse?
+     * @param {DecoderOptions|string} [options={}] Options or encoding
+     *   for input.
+     * @returns {Array<ExtendedResults>|Array<any>} Array of all found items.
+     * @throws {TypeError} No input provided.
+     * @throws {Error} Insufficient data provided.
+     */
+    static decodeAllSync(input: BufferLike, options?: DecoderOptions | string): Array<ExtendedResults> | Array<any>;
+    /**
+     * Decode the first CBOR item in the input.  This will error if there are
+     * more bytes left over at the end (if options.extendedResults is not true),
+     * and optionally if there were no valid CBOR bytes in the input.  Emits the
+     * {Decoder.NOT_FOUND} Symbol in the callback if no data was found and the
+     * `required` option is false.
+     *
+     * @static
+     * @param {BufferLike} input What to parse?
+     * @param {DecoderOptions|decodeCallback|string} [options={}] Options, the
+     *   callback, or input encoding.
+     * @param {decodeCallback} [cb] Callback.
+     * @returns {Promise<ExtendedResults|any>} Returned even if callback is
+     *   specified.
+     * @throws {TypeError} No input provided.
+     */
+    static decodeFirst(input: BufferLike, options?: DecoderOptions | decodeCallback | string, cb?: decodeCallback): Promise<ExtendedResults | any>;
+    /**
+     * @callback decodeAllCallback
+     * @param {Error} error If one was generated.
+     * @param {Array<ExtendedResults>|Array<any>} value All of the decoded
+     *   values, wrapped in an Array.
+     */
+    /**
+     * Decode all of the CBOR items in the input.  This will error if there are
+     * more bytes left over at the end.
+     *
+     * @static
+     * @param {BufferLike} input What to parse?
+     * @param {DecoderOptions|decodeAllCallback|string} [options={}]
+     *   Decoding options, the callback, or the input encoding.
+     * @param {decodeAllCallback} [cb] Callback.
+     * @returns {Promise<Array<ExtendedResults>|Array<any>>} Even if callback
+     *   is specified.
+     * @throws {TypeError} No input specified.
+     */
+    static decodeAll(input: BufferLike, options?: string | DecoderOptions | ((error: Error, value: Array<ExtendedResults> | Array<any>) => any), cb?: (error: Error, value: Array<ExtendedResults> | Array<any>) => any): Promise<Array<ExtendedResults> | Array<any>>;
+    /**
+     * Create a parsing stream.
+     *
+     * @param {DecoderOptions} [options={}] Options.
+     */
+    constructor(options?: DecoderOptions);
+    running: boolean;
+    max_depth: number;
+    tags: {
+        [x: string]: Tagged.TagFunction;
+    };
+    preferWeb: boolean;
+    extendedResults: boolean;
+    required: boolean;
+    preventDuplicateKeys: boolean;
+    valueBytes: NoFilter;
+    /**
+     * Stop processing.
+     */
+    close(): void;
+    /**
+     * Only called if extendedResults is true.
+     *
+     * @ignore
+     */
+    _onRead(data: any): void;
+}
+declare namespace Decoder {
+    export { NOT_FOUND, BufferLike, ExtendedResults, DecoderOptions, decodeCallback };
+}
+import BinaryParseStream = require("../vendor/binary-parse-stream");
+import Tagged = require("./tagged");
+import NoFilter = require("nofilter");
+/**
+ * Things that can act as inputs, from which a NoFilter can be created.
+ */
+type BufferLike = string | Buffer | ArrayBuffer | Uint8Array | Uint8ClampedArray | DataView | stream.Readable;
+type DecoderOptions = {
+    /**
+     * The maximum depth to parse.
+     * Use -1 for "until you run out of memory".  Set this to a finite
+     * positive number for un-trusted inputs.  Most standard inputs won't nest
+     * more than 100 or so levels; I've tested into the millions before
+     * running out of memory.
+     */
+    max_depth?: number;
+    /**
+     * Mapping from tag number to function(v),
+     * where v is the decoded value that comes after the tag, and where the
+     * function returns the correctly-created value for that tag.
+     */
+    tags?: Tagged.TagMap;
+    /**
+     * If true, prefer Uint8Arrays to
+     * be generated instead of node Buffers.  This might turn on some more
+     * changes in the future, so forward-compatibility is not guaranteed yet.
+     */
+    preferWeb?: boolean;
+    /**
+     * The encoding of the input.
+     * Ignored if input is a Buffer.
+     */
+    encoding?: BufferEncoding;
+    /**
+     * Should an error be thrown when no
+     * data is in the input?
+     */
+    required?: boolean;
+    /**
+     * If true, emit extended
+     * results, which will be an object with shape {@link ExtendedResults }.
+     * The value will already have been null-checked.
+     */
+    extendedResults?: boolean;
+    /**
+     * If true, error is
+     * thrown if a map has duplicate keys.
+     */
+    preventDuplicateKeys?: boolean;
+};
+type ExtendedResults = {
+    /**
+     * The value that was found.
+     */
+    value: any;
+    /**
+     * The number of bytes of the original input that
+     * were read.
+     */
+    length: number;
+    /**
+     * The bytes of the original input that were used
+     * to produce the value.
+     */
+    bytes: Buffer;
+    /**
+     * The bytes that were left over from the original
+     * input.  This property only exists if {@linkcode Decoder.decodeFirst } or
+     * {@linkcode Decoder.decodeFirstSync } was called.
+     */
+    unused?: Buffer;
+};
+type decodeCallback = (error?: Error, value?: any) => void;
+declare const NOT_FOUND: unique symbol;
+import { Buffer } from "buffer";
+import stream = require("stream");

--- a/packages/cbor-web/types/lib/diagnose.d.ts
+++ b/packages/cbor-web/types/lib/diagnose.d.ts
@@ -1,0 +1,91 @@
+export = Diagnose;
+/**
+ * Output the diagnostic format from a stream of CBOR bytes.
+ *
+ * @extends stream.Transform
+ */
+declare class Diagnose extends stream.Transform {
+    /**
+     * Convenience function to return a string in diagnostic format.
+     *
+     * @param {BufferLike} input The CBOR bytes to format.
+     * @param {DiagnoseOptions |diagnoseCallback|string} [options={}]
+     *   Options, the callback, or the input encoding.
+     * @param {diagnoseCallback} [cb] Callback.
+     * @throws {TypeError} Input not provided.
+     * @returns {Promise} If callback not specified.
+     */
+    static diagnose(input: BufferLike, options?: DiagnoseOptions | diagnoseCallback | string, cb?: diagnoseCallback): Promise<any>;
+    /**
+     * Creates an instance of Diagnose.
+     *
+     * @param {DiagnoseOptions} [options={}] Options for creation.
+     */
+    constructor(options?: DiagnoseOptions);
+    float_bytes: number;
+    separator: string;
+    stream_errors: boolean;
+    parser: Decoder;
+    /**
+     * @ignore
+     */
+    _on_error(er: any): void;
+    /** @private */
+    private _on_more;
+    /** @private */
+    private _fore;
+    /** @private */
+    private _on_value;
+    /** @private */
+    private _on_start;
+    /** @private */
+    private _on_stop;
+    /** @private */
+    private _on_data;
+}
+declare namespace Diagnose {
+    export { BufferLike, DiagnoseOptions, diagnoseCallback };
+}
+import stream = require("stream");
+import Decoder = require("./decoder");
+/**
+ * Things that can act as inputs, from which a NoFilter can be created.
+ */
+type BufferLike = string | Buffer | ArrayBuffer | Uint8Array | Uint8ClampedArray | DataView | stream.Readable;
+type DiagnoseOptions = {
+    /**
+     * Output between detected objects.
+     */
+    separator?: string;
+    /**
+     * Put error info into the
+     * output stream.
+     */
+    stream_errors?: boolean;
+    /**
+     * The maximum depth to parse.
+     * Use -1 for "until you run out of memory".  Set this to a finite
+     * positive number for un-trusted inputs.  Most standard inputs won't nest
+     * more than 100 or so levels; I've tested into the millions before
+     * running out of memory.
+     */
+    max_depth?: number;
+    /**
+     * Mapping from tag number to function(v),
+     * where v is the decoded value that comes after the tag, and where the
+     * function returns the correctly-created value for that tag.
+     */
+    tags?: object;
+    /**
+     * If true, prefer Uint8Arrays to
+     * be generated instead of node Buffers.  This might turn on some more
+     * changes in the future, so forward-compatibility is not guaranteed yet.
+     */
+    preferWeb?: boolean;
+    /**
+     * The encoding of input, ignored if
+     * input is not string.
+     */
+    encoding?: BufferEncoding;
+};
+type diagnoseCallback = (error?: Error, value?: string) => void;

--- a/packages/cbor-web/types/lib/encoder.d.ts
+++ b/packages/cbor-web/types/lib/encoder.d.ts
@@ -1,0 +1,463 @@
+/// <reference types="node" />
+export = Encoder;
+/**
+ * @typedef EncodingOptions
+ * @property {any[]|object} [genTypes=[]] Array of pairs of
+ *   `type`, `function(Encoder)` for semantic types to be encoded.  Not
+ *   needed for Array, Date, Buffer, Map, RegExp, Set, or URL.
+ *   If an object, the keys are the constructor names for the types.
+ * @property {boolean} [canonical=false] Should the output be
+ *   canonicalized.
+ * @property {boolean|WeakSet} [detectLoops=false] Should object loops
+ *   be detected?  This will currently add memory to track every part of the
+ *   object being encoded in a WeakSet.  Do not encode
+ *   the same object twice on the same encoder, without calling
+ *   `removeLoopDetectors` in between, which will clear the WeakSet.
+ *   You may pass in your own WeakSet to be used; this is useful in some
+ *   recursive scenarios.
+ * @property {("number"|"float"|"int"|"string")} [dateType="number"] -
+ *   how should dates be encoded?  "number" means float or int, if no
+ *   fractional seconds.
+ * @property {any} [encodeUndefined=undefined] How should an
+ *   "undefined" in the input be encoded.  By default, just encode a CBOR
+ *   undefined.  If this is a buffer, use those bytes without re-encoding
+ *   them.  If this is a function, the function will be called (which is a
+ *   good time to throw an exception, if that's what you want), and the
+ *   return value will be used according to these rules.  Anything else will
+ *   be encoded as CBOR.
+ * @property {boolean} [disallowUndefinedKeys=false] Should
+ *   "undefined" be disallowed as a key in a Map that is serialized?  If
+ *   this is true, encode(new Map([[undefined, 1]])) will throw an
+ *   exception.  Note that it is impossible to get a key of undefined in a
+ *   normal JS object.
+ * @property {boolean} [collapseBigIntegers=false] Should integers
+ *   that come in as ECMAscript bigint's be encoded
+ *   as normal CBOR integers if they fit, discarding type information?
+ * @property {number} [chunkSize=4096] Number of characters or bytes
+ *   for each chunk, if obj is a string or Buffer, when indefinite encoding.
+ * @property {boolean} [omitUndefinedProperties=false] When encoding
+ *   objects or Maps, do not include a key if its corresponding value is
+ *   `undefined`.
+ */
+/**
+ * Transform JavaScript values into CBOR bytes.  The `Writable` side of
+ * the stream is in object mode.
+ *
+ * @extends stream.Transform
+ */
+declare class Encoder extends stream.Transform {
+    /**
+     * Encode an array and all of its elements.
+     *
+     * @param {Encoder} gen Encoder to use.
+     * @param {any[]} obj Array to encode.
+     * @param {object} [opts] Options.
+     * @param {boolean} [opts.indefinite=false] Use indefinite encoding?
+     * @returns {boolean} True on success.
+     */
+    static pushArray(gen: Encoder, obj: any[], opts?: {
+        indefinite?: boolean;
+    }): boolean;
+    /**
+     * @param {Encoder} gen Encoder.
+     * @param {Date} obj Date to encode.
+     * @returns {boolean} True on success.
+     * @ignore
+     */
+    static _pushDate(gen: Encoder, obj: Date): boolean;
+    /**
+     * @param {Encoder} gen Encoder.
+     * @param {Buffer} obj Buffer to encode.
+     * @returns {boolean} True on success.
+     * @ignore
+     */
+    static _pushBuffer(gen: Encoder, obj: Buffer): boolean;
+    /**
+     * @param {Encoder} gen Encoder.
+     * @param {NoFilter} obj Buffer to encode.
+     * @returns {boolean} True on success.
+     * @ignore
+     */
+    static _pushNoFilter(gen: Encoder, obj: NoFilter): boolean;
+    /**
+     * @param {Encoder} gen Encoder.
+     * @param {RegExp} obj RegExp to encode.
+     * @returns {boolean} True on success.
+     * @ignore
+     */
+    static _pushRegexp(gen: Encoder, obj: RegExp): boolean;
+    /**
+     * @param {Encoder} gen Encoder.
+     * @param {Set} obj Set to encode.
+     * @returns {boolean} True on success.
+     * @ignore
+     */
+    static _pushSet(gen: Encoder, obj: Set<any>): boolean;
+    /**
+     * @param {Encoder} gen Encoder.
+     * @param {URL} obj URL to encode.
+     * @returns {boolean} True on success.
+     * @ignore
+     */
+    static _pushURL(gen: Encoder, obj: URL): boolean;
+    /**
+     * @param {Encoder} gen Encoder.
+     * @param {object} obj Boxed String, Number, or Boolean object to encode.
+     * @returns {boolean} True on success.
+     * @ignore
+     */
+    static _pushBoxed(gen: Encoder, obj: object): boolean;
+    /**
+     * @param {Encoder} gen Encoder.
+     * @param {Map} obj Map to encode.
+     * @returns {boolean} True on success.
+     * @throws {Error} Map key that is undefined.
+     * @ignore
+     */
+    static _pushMap(gen: Encoder, obj: Map<any, any>, opts: any): boolean;
+    /**
+     * @param {Encoder} gen Encoder.
+     * @param {NodeJS.TypedArray} obj Array to encode.
+     * @returns {boolean} True on success.
+     * @ignore
+     */
+    static _pushTypedArray(gen: Encoder, obj: NodeJS.TypedArray): boolean;
+    /**
+     * @param {Encoder} gen Encoder.
+     * @param { ArrayBuffer } obj Array to encode.
+     * @returns {boolean} True on success.
+     * @ignore
+     */
+    static _pushArrayBuffer(gen: Encoder, obj: ArrayBuffer): boolean;
+    /**
+     * Encode the given object with indefinite length.  There are apparently
+     * some (IMO) broken implementations of poorly-specified protocols that
+     * REQUIRE indefinite-encoding.  See the example for how to add this as an
+     * `encodeCBOR` function to an object or class to get indefinite encoding.
+     *
+     * @param {Encoder} gen The encoder to use.
+     * @param {string|Buffer|Array|Map|object} [obj] The object to encode.  If
+     *   null, use "this" instead.
+     * @param {EncodingOptions} [options={}] Options for encoding.
+     * @returns {boolean} True on success.
+     * @throws {Error} No object to encode or invalid indefinite encoding.
+     * @example <caption>Force indefinite encoding:</caption>
+     * const o = {
+     *   a: true,
+     *   encodeCBOR: cbor.Encoder.encodeIndefinite,
+     * }
+     * const m = []
+     * m.encodeCBOR = cbor.Encoder.encodeIndefinite
+     * cbor.encodeOne([o, m])
+     */
+    static encodeIndefinite(gen: Encoder, obj?: string | Buffer | any[] | Map<any, any> | object, options?: EncodingOptions): boolean;
+    /**
+     * Encode one or more JavaScript objects, and return a Buffer containing the
+     * CBOR bytes.
+     *
+     * @param {...any} objs The objects to encode.
+     * @returns {Buffer} The encoded objects.
+     */
+    static encode(...objs: any[]): Buffer;
+    /**
+     * Encode one or more JavaScript objects canonically (slower!), and return
+     * a Buffer containing the CBOR bytes.
+     *
+     * @param {...any} objs The objects to encode.
+     * @returns {Buffer} The encoded objects.
+     */
+    static encodeCanonical(...objs: any[]): Buffer;
+    /**
+     * Encode one JavaScript object using the given options.
+     *
+     * @static
+     * @param {any} obj The object to encode.
+     * @param {EncodingOptions} [options={}] Passed to the Encoder constructor.
+     * @returns {Buffer} The encoded objects.
+     */
+    static encodeOne(obj: any, options?: EncodingOptions): Buffer;
+    /**
+     * Encode one JavaScript object using the given options in a way that
+     * is more resilient to objects being larger than the highWaterMark
+     * number of bytes.  As with the other static encode functions, this
+     * will still use a large amount of memory.  Use a stream-based approach
+     * directly if you need to process large and complicated inputs.
+     *
+     * @param {any} obj The object to encode.
+     * @param {EncodingOptions} [options={}] Passed to the Encoder constructor.
+     * @returns {Promise<Buffer>} A promise for the encoded buffer.
+     */
+    static encodeAsync(obj: any, options?: EncodingOptions): Promise<Buffer>;
+    static set SEMANTIC_TYPES(arg: {
+        [x: string]: EncodeFunction;
+    });
+    /**
+     * The currently supported set of semantic types.  May be modified by plugins.
+     *
+     * @type {SemanticMap}
+     */
+    static get SEMANTIC_TYPES(): {
+        [x: string]: EncodeFunction;
+    };
+    /**
+     * Reset the supported semantic types to the original set, before any
+     * plugins modified the list.
+     */
+    static reset(): void;
+    /**
+     * Creates an instance of Encoder.
+     *
+     * @param {EncodingOptions} [options={}] Options for the encoder.
+     */
+    constructor(options?: EncodingOptions);
+    canonical: boolean;
+    encodeUndefined: any;
+    disallowUndefinedKeys: boolean;
+    dateType: "string" | "number" | "float" | "int";
+    collapseBigIntegers: boolean;
+    /** @type {WeakSet?} */
+    detectLoops: WeakSet<any> | null;
+    omitUndefinedProperties: boolean;
+    semanticTypes: {
+        [x: string]: EncodeFunction;
+    };
+    /**
+     * @param {number} val Number(0-255) to encode.
+     * @returns {boolean} True on success.
+     * @ignore
+     */
+    _pushUInt8(val: number): boolean;
+    /**
+     * @param {number} val Number(0-65535) to encode.
+     * @returns {boolean} True on success.
+     * @ignore
+     */
+    _pushUInt16BE(val: number): boolean;
+    /**
+     * @param {number} val Number(0..2**32-1) to encode.
+     * @returns {boolean} True on success.
+     * @ignore
+     */
+    _pushUInt32BE(val: number): boolean;
+    /**
+     * @param {number} val Number to encode as 4-byte float.
+     * @returns {boolean} True on success.
+     * @ignore
+     */
+    _pushFloatBE(val: number): boolean;
+    /**
+     * @param {number} val Number to encode as 8-byte double.
+     * @returns {boolean} True on success.
+     * @ignore
+     */
+    _pushDoubleBE(val: number): boolean;
+    /**
+     * @returns {boolean} True on success.
+     * @ignore
+     */
+    _pushNaN(): boolean;
+    /**
+     * @param {number} obj Positive or negative infinity.
+     * @returns {boolean} True on success.
+     * @ignore
+     */
+    _pushInfinity(obj: number): boolean;
+    /**
+     * Choose the best float representation for a number and encode it.
+     *
+     * @param {number} obj A number that is known to be not-integer, but not
+     *    how many bytes of precision it needs.
+     * @returns {boolean} True on success.
+     * @ignore
+     */
+    _pushFloat(obj: number): boolean;
+    /**
+     * Choose the best integer representation for a postive number and encode
+     * it.  If the number is over MAX_SAFE_INTEGER, fall back on float (but I
+     * don't remember why).
+     *
+     * @param {number} obj A positive number that is known to be an integer,
+     *    but not how many bytes of precision it needs.
+     * @param {number} mt The Major Type number to combine with the integer.
+     *    Not yet shifted.
+     * @param {number} [orig] The number before it was transformed to positive.
+     *    If the mt is NEG_INT, and the positive number is over MAX_SAFE_INT,
+     *    then we'll encode this as a float rather than making the number
+     *    negative again and losing precision.
+     * @returns {boolean} True on success.
+     * @ignore
+     */
+    _pushInt(obj: number, mt: number, orig?: number): boolean;
+    /**
+     * Choose the best integer representation for a number and encode it.
+     *
+     * @param {number} obj A number that is known to be an integer,
+     *    but not how many bytes of precision it needs.
+     * @returns {boolean} True on success.
+     * @ignore
+     */
+    _pushIntNum(obj: number): boolean;
+    /**
+     * @param {number} obj Plain JS number to encode.
+     * @returns {boolean} True on success.
+     * @ignore
+     */
+    _pushNumber(obj: number): boolean;
+    /**
+     * @param {string} obj String to encode.
+     * @returns {boolean} True on success.
+     * @ignore
+     */
+    _pushString(obj: string): boolean;
+    /**
+     * @param {boolean} obj Bool to encode.
+     * @returns {boolean} True on success.
+     * @ignore
+     */
+    _pushBoolean(obj: boolean): boolean;
+    /**
+     * @param {undefined} obj Ignored.
+     * @returns {boolean} True on success.
+     * @ignore
+     */
+    _pushUndefined(obj: undefined): boolean;
+    /**
+     * @param {null} obj Ignored.
+     * @returns {boolean} True on success.
+     * @ignore
+     */
+    _pushNull(obj: null): boolean;
+    /**
+     * @param {number} tag Tag number to encode.
+     * @returns {boolean} True on success.
+     * @ignore
+     */
+    _pushTag(tag: number): boolean;
+    /**
+     * @param {bigint} obj BigInt to encode.
+     * @returns {boolean} True on success.
+     * @ignore
+     */
+    _pushJSBigint(obj: bigint): boolean;
+    /**
+     * @param {object} obj Object to encode.
+     * @returns {boolean} True on success.
+     * @throws {Error} Loop detected.
+     * @ignore
+     */
+    _pushObject(obj: object, opts: any): boolean;
+    /**
+     * @param {any[]} objs Array of supported things.
+     * @returns {Buffer} Concatenation of encodings for the supported things.
+     * @ignore
+     */
+    _encodeAll(objs: any[]): Buffer;
+    /**
+     * Add an encoding function to the list of supported semantic types.  This
+     * is useful for objects for which you can't add an encodeCBOR method.
+     *
+     * @param {string|Function} type The type to encode.
+     * @param {EncodeFunction} fun The encoder to use.
+     * @returns {EncodeFunction?} The previous encoder or undefined if there
+     *   wasn't one.
+     * @throws {TypeError} Invalid function.
+     */
+    addSemanticType(type: string | Function, fun: EncodeFunction): EncodeFunction | null;
+    /**
+     * Push any supported type onto the encoded stream.
+     *
+     * @param {any} obj The thing to encode.
+     * @returns {boolean} True on success.
+     * @throws {TypeError} Unknown type for obj.
+     */
+    pushAny(obj: any): boolean;
+    /**
+     * Remove the loop detector WeakSet for this Encoder.
+     *
+     * @returns {boolean} True when the Encoder was reset, else false.
+     */
+    removeLoopDetectors(): boolean;
+}
+declare namespace Encoder {
+    export { EncodeFunction, SemanticMap, EncodingOptions };
+}
+import stream = require("stream");
+/**
+ * Generate the CBOR for a value.  If you are using this, you'll either need
+ * to call {@link Encoder.write } with a Buffer, or look into the internals of
+ * Encoder to reuse existing non-documented behavior.
+ */
+type EncodeFunction = (enc: Encoder, val: any) => boolean;
+import { Buffer } from "buffer";
+import NoFilter = require("nofilter");
+type EncodingOptions = {
+    /**
+     * Array of pairs of
+     * `type`, `function(Encoder)` for semantic types to be encoded.  Not
+     * needed for Array, Date, Buffer, Map, RegExp, Set, or URL.
+     * If an object, the keys are the constructor names for the types.
+     */
+    genTypes?: any[] | object;
+    /**
+     * Should the output be
+     * canonicalized.
+     */
+    canonical?: boolean;
+    /**
+     * Should object loops
+     * be detected?  This will currently add memory to track every part of the
+     * object being encoded in a WeakSet.  Do not encode
+     * the same object twice on the same encoder, without calling
+     * `removeLoopDetectors` in between, which will clear the WeakSet.
+     * You may pass in your own WeakSet to be used; this is useful in some
+     * recursive scenarios.
+     */
+    detectLoops?: boolean | WeakSet<any>;
+    /**
+     * -
+     * how should dates be encoded?  "number" means float or int, if no
+     * fractional seconds.
+     */
+    dateType?: ("number" | "float" | "int" | "string");
+    /**
+     * How should an
+     * "undefined" in the input be encoded.  By default, just encode a CBOR
+     * undefined.  If this is a buffer, use those bytes without re-encoding
+     * them.  If this is a function, the function will be called (which is a
+     * good time to throw an exception, if that's what you want), and the
+     * return value will be used according to these rules.  Anything else will
+     * be encoded as CBOR.
+     */
+    encodeUndefined?: any;
+    /**
+     * Should
+     * "undefined" be disallowed as a key in a Map that is serialized?  If
+     * this is true, encode(new Map([[undefined, 1]])) will throw an
+     * exception.  Note that it is impossible to get a key of undefined in a
+     * normal JS object.
+     */
+    disallowUndefinedKeys?: boolean;
+    /**
+     * Should integers
+     * that come in as ECMAscript bigint's be encoded
+     * as normal CBOR integers if they fit, discarding type information?
+     */
+    collapseBigIntegers?: boolean;
+    /**
+     * Number of characters or bytes
+     * for each chunk, if obj is a string or Buffer, when indefinite encoding.
+     */
+    chunkSize?: number;
+    /**
+     * When encoding
+     * objects or Maps, do not include a key if its corresponding value is
+     * `undefined`.
+     */
+    omitUndefinedProperties?: boolean;
+};
+/**
+ * A mapping from tag number to a tag decoding function.
+ */
+type SemanticMap = {
+    [x: string]: EncodeFunction;
+};

--- a/packages/cbor-web/types/lib/map.d.ts
+++ b/packages/cbor-web/types/lib/map.d.ts
@@ -1,0 +1,81 @@
+export = CborMap;
+/**
+ * Wrapper around a JavaScript Map object that allows the keys to be
+ * any complex type.  The base Map object allows this, but will only
+ * compare the keys by identity, not by value.  CborMap translates keys
+ * to CBOR first (and base64's them to ensure by-value comparison).
+ *
+ * This is not a subclass of Object, because it would be tough to get
+ * the semantics to be an exact match.
+ *
+ * @extends Map
+ */
+declare class CborMap extends Map<any, any> {
+    /**
+     * @ignore
+     */
+    static _encode(key: any): string;
+    /**
+     * @ignore
+     */
+    static _decode(key: any): any;
+    /**
+     * Creates an instance of CborMap.
+     *
+     * @param {Iterable<any>} [iterable] An Array or other iterable
+     *   object whose elements are key-value pairs (arrays with two elements, e.g.
+     *   <code>[[ 1, 'one' ],[ 2, 'two' ]]</code>). Each key-value pair is added
+     *   to the new CborMap; null values are treated as undefined.
+     */
+    constructor(iterable?: Iterable<any>);
+    /**
+     * Adds or updates an element with a specified key and value.
+     *
+     * @param {any} key The key identifying the element to store.
+     *   Can be any type, which will be serialized into CBOR and compared by
+     *   value.
+     * @param {any} val The element to store.
+     * @returns {this} This object.
+     */
+    set(key: any, val: any): this;
+    /**
+     * Returns a new Iterator object that contains the keys for each element
+     * in the Map object in insertion order.  The keys are decoded into their
+     * original format.
+     *
+     * @yields {any} The keys of the map.
+     */
+    keys(): Generator<any, void, unknown>;
+    /**
+     * Returns a new Iterator object that contains the [key, value] pairs for
+     * each element in the Map object in insertion order.
+     *
+     * @yields {any[]} Key value pairs.
+     * @returns {IterableIterator<any, any>} Key value pairs.
+     */
+    entries(): IterableIterator<any, any>;
+    /**
+     * Executes a provided function once per each key/value pair in the Map
+     * object, in insertion order.
+     *
+     * @param {function(any, any, Map): undefined} fun Function to execute for
+     *  each element, which takes a value, a key, and the Map being traversed.
+     * @param {any} thisArg Value to use as this when executing callback.
+     * @throws {TypeError} Invalid function.
+     */
+    forEach(fun: (arg0: any, arg1: any, arg2: Map<any, any>) => undefined, thisArg: any): void;
+    /**
+     * Push the simple value onto the CBOR stream.
+     *
+     * @param {object} gen The generator to push onto.
+     * @returns {boolean} True on success.
+     */
+    encodeCBOR(gen: object): boolean;
+    /**
+     * Returns a new Iterator object that contains the [key, value] pairs for
+     * each element in the Map object in insertion order.
+     *
+     * @returns {IterableIterator} Key value pairs.
+     */
+    [Symbol.iterator](): IterableIterator<any>;
+}

--- a/packages/cbor-web/types/lib/simple.d.ts
+++ b/packages/cbor-web/types/lib/simple.d.ts
@@ -1,0 +1,47 @@
+export = Simple;
+/**
+ * A CBOR Simple Value that does not map onto a known constant.
+ */
+declare class Simple {
+    /**
+     * Is the given object a Simple?
+     *
+     * @param {any} obj Object to test.
+     * @returns {boolean} Is it Simple?
+     */
+    static isSimple(obj: any): boolean;
+    /**
+     * Decode from the CBOR additional information into a JavaScript value.
+     * If the CBOR item has no parent, return a "safe" symbol instead of
+     * `null` or `undefined`, so that the value can be passed through a
+     * stream in object mode.
+     *
+     * @param {number} val The CBOR additional info to convert.
+     * @param {boolean} [has_parent=true] Does the CBOR item have a parent?
+     * @param {boolean} [parent_indefinite=false] Is the parent element
+     *   indefinitely encoded?
+     * @returns {(null|undefined|boolean|symbol|Simple)} The decoded value.
+     * @throws {Error} Invalid BREAK.
+     */
+    static decode(val: number, has_parent?: boolean, parent_indefinite?: boolean): (null | undefined | boolean | symbol | Simple);
+    /**
+     * Creates an instance of Simple.
+     *
+     * @param {number} value The simple value's integer value.
+     */
+    constructor(value: number);
+    value: number;
+    /**
+     * Debug string for simple value.
+     *
+     * @returns {string} Formated string of `simple(value)`.
+     */
+    toString(): string;
+    /**
+     * Push the simple value onto the CBOR stream.
+     *
+     * @param {object} gen The generator to push onto.
+     * @returns {boolean} True on success.
+     */
+    encodeCBOR(gen: object): boolean;
+}

--- a/packages/cbor-web/types/lib/tagged.d.ts
+++ b/packages/cbor-web/types/lib/tagged.d.ts
@@ -1,0 +1,78 @@
+export = Tagged;
+/**
+ * A CBOR tagged item, where the tag does not have semantics specified at the
+ * moment, or those semantics threw an error during parsing. Typically this will
+ * be an extension point you're not yet expecting.
+ */
+declare class Tagged {
+    static set TAGS(arg: {
+        [x: string]: TagFunction;
+    });
+    /**
+     * The current set of supported tags.  May be modified by plugins.
+     *
+     * @type {TagMap}
+     * @static
+     */
+    static get TAGS(): {
+        [x: string]: TagFunction;
+    };
+    /**
+     * Reset the supported tags to the original set, before any plugins modified
+     * the list.
+     */
+    static reset(): void;
+    /**
+     * Creates an instance of Tagged.
+     *
+     * @param {number} tag The number of the tag.
+     * @param {any} value The value inside the tag.
+     * @param {Error} [err] The error that was thrown parsing the tag, or null.
+     */
+    constructor(tag: number, value: any, err?: Error);
+    tag: number;
+    value: any;
+    err: Error;
+    toJSON(): any;
+    /**
+     * Convert to a String.
+     *
+     * @returns {string} String of the form '1(2)'.
+     */
+    toString(): string;
+    /**
+     * Push the simple value onto the CBOR stream.
+     *
+     * @param {object} gen The generator to push onto.
+     * @returns {boolean} True on success.
+     */
+    encodeCBOR(gen: object): boolean;
+    /**
+     * If we have a converter for this type, do the conversion.  Some converters
+     * are built-in.  Additional ones can be passed in.  If you want to remove
+     * a built-in converter, pass a converter in whose value is 'null' instead
+     * of a function.
+     *
+     * @param {object} converters Keys in the object are a tag number, the value
+     *   is a function that takes the decoded CBOR and returns a JavaScript value
+     *   of the appropriate type.  Throw an exception in the function on errors.
+     * @returns {any} The converted item.
+     */
+    convert(converters: object): any;
+}
+declare namespace Tagged {
+    export { INTERNAL_JSON, TagFunction, TagMap };
+}
+/**
+ * Convert a tagged value to a more interesting JavaScript type.  Errors
+ * thrown in this function will be captured into the "err" property of the
+ * original Tagged instance.
+ */
+type TagFunction = (value: any, tag: Tagged) => any;
+declare const INTERNAL_JSON: unique symbol;
+/**
+ * A mapping from tag number to a tag decoding function.
+ */
+type TagMap = {
+    [x: string]: TagFunction;
+};

--- a/packages/cbor-web/types/lib/utils.d.ts
+++ b/packages/cbor-web/types/lib/utils.d.ts
@@ -1,0 +1,21 @@
+/// <reference types="node" />
+export function utf8(buf: any): string;
+export namespace utf8 {
+    const checksUTF8: boolean;
+}
+export function isBufferish(b: any): boolean;
+export function bufferishToBuffer(b: any): Buffer;
+export function parseCBORint(ai: any, buf: any): any;
+export function writeHalf(buf: any, half: any): boolean;
+export function parseHalf(buf: any): number;
+export function parseCBORfloat(buf: any): any;
+export function hex(s: any): Buffer;
+export function bin(s: any): Buffer;
+export function arrayEqual(a: any, b: any): any;
+export function bufferToBigInt(buf: any): bigint;
+export function cborValueToString(val: any, float_bytes?: number): any;
+export function guessEncoding(input: any, encoding: any): any;
+export function base64url(buf: Buffer | Uint8Array | Uint8ClampedArray | ArrayBuffer | DataView): string;
+export function base64(buf: Buffer | Uint8Array | Uint8ClampedArray | ArrayBuffer | DataView): string;
+export function isBigEndian(): boolean;
+import { Buffer } from "buffer";

--- a/packages/cbor-web/types/vendor/binary-parse-stream/index.d.ts
+++ b/packages/cbor-web/types/vendor/binary-parse-stream/index.d.ts
@@ -1,0 +1,34 @@
+export = BinaryParseStream;
+/**
+ * BinaryParseStream is a TransformStream that consumes buffers and outputs
+ * objects on the other end.  It expects your subclass to implement a `_parse`
+ * method that is a generator.  When your generator yields a number, it'll be
+ * fed a buffer of that length from the input.  When your generator returns,
+ * the return value will be pushed to the output side.
+ *
+ * @extends stream.Transform
+ */
+declare class BinaryParseStream extends stream.Transform {
+    /**
+     * Creates an instance of BinaryParseStream.
+     *
+     * @param {stream.TransformOptions} options Stream options.
+     * @memberof BinaryParseStream
+     */
+    constructor(options: stream.TransformOptions);
+    bs: NoFilter;
+    __fresh: boolean;
+    __needed: any;
+    /**
+     * Subclasses must override this to set their parsing behavior.  Yield a
+     * number to receive a Buffer of that many bytes.
+     *
+     * @abstract
+     * @returns {Generator<number, any, Buffer>}
+     */
+    _parse(): Generator<number, any, Buffer>;
+    __restart(): void;
+    __parser: Generator<number, any, Buffer>;
+}
+import stream = require("stream");
+import NoFilter = require("nofilter");

--- a/packages/cbor/package.json
+++ b/packages/cbor/package.json
@@ -43,7 +43,8 @@
     "Denis Lapaev <den@lapaev.me> (http://lapaev.me/)",
     "Ruben Bridgewater <ruben@bridgewater.de>",
     "Burt Harris <Burt_Harris_cbor@azxs.33mail.com>",
-    "Jakub Arbet <hi@jakubarbet.me> (https://jakubarbet.me/)"
+    "Jakub Arbet <hi@jakubarbet.me> (https://jakubarbet.me/)",
+    "Rouzbeh Karimi <rouzweltt@gmail.com> (https://github.com/rouzwelt)"
   ],
   "types": "./types/lib/cbor.d.ts",
   "dependencies": {

--- a/packages/cbor/package.json
+++ b/packages/cbor/package.json
@@ -23,7 +23,7 @@
     "release": "npm version patch && git push --follow-tags && npm publish",
     "predev": "npm run coverage",
     "dev": "light-server -q -s. -w 'lib/*.js,test/*.js # npm run coverage' -o /coverage/lcov-report/index.html",
-    "types": "tsc"
+    "types": "tsc && cp -r ./types ../cbor-web/"
   },
   "keywords": [
     "coap",

--- a/packages/cbor/package.json
+++ b/packages/cbor/package.json
@@ -23,7 +23,8 @@
     "release": "npm version patch && git push --follow-tags && npm publish",
     "predev": "npm run coverage",
     "dev": "light-server -q -s. -w 'lib/*.js,test/*.js # npm run coverage' -o /coverage/lcov-report/index.html",
-    "types": "tsc && (cp -r ./types ../cbor-web/ || xcopy types ..\\cbor-web /E)"
+    "types": "tsc && npm run copy-types",
+    "copy-types": "copyfiles \"./types/**\" \"../cbor-web/\""
   },
   "keywords": [
     "coap",

--- a/packages/cbor/package.json
+++ b/packages/cbor/package.json
@@ -23,7 +23,7 @@
     "release": "npm version patch && git push --follow-tags && npm publish",
     "predev": "npm run coverage",
     "dev": "light-server -q -s. -w 'lib/*.js,test/*.js # npm run coverage' -o /coverage/lcov-report/index.html",
-    "types": "tsc && cp -r ./types ../cbor-web/"
+    "types": "tsc && (cp -r ./types ../cbor-web/ || xcopy types ..\cbor-web /E)"
   },
   "keywords": [
     "coap",

--- a/packages/cbor/package.json
+++ b/packages/cbor/package.json
@@ -23,7 +23,7 @@
     "release": "npm version patch && git push --follow-tags && npm publish",
     "predev": "npm run coverage",
     "dev": "light-server -q -s. -w 'lib/*.js,test/*.js # npm run coverage' -o /coverage/lcov-report/index.html",
-    "types": "tsc && (cp -r ./types ../cbor-web/ || xcopy types ..\cbor-web /E)"
+    "types": "tsc && (cp -r ./types ../cbor-web/ || xcopy types ..\\cbor-web /E)"
   },
   "keywords": [
     "coap",


### PR DESCRIPTION
add types (dts) to cbor-web when they are generated for cobr package, so cbor-web can be used in typescript browser projects easily.

this is the simplest solution I could come up with to include types for cbor-web, however better solutions possibly can be achieved by original authors as they are much more familar with the monorepo structure.